### PR TITLE
Converted old format to new yaml format

### DIFF
--- a/elixir.yaml
+++ b/elixir.yaml
@@ -1,0 +1,19 @@
+filetype: elixir
+
+detect: 
+    filename: "\\.exs$|\\.ex$"
+
+rules:
+    - identifier: "\\b(fn|function|def|do|do:|for:|end|defmodule|defstruct|if|else|case|in|receive|after|try|catch|cond|defrecord|defrecordp|require|use|test|setup|teardown|defmacro|defmacrop|defdelegate|defexception|defimpl|defoverridable|defp|defprotocol|import|when|and|or|not|xor|lc|inlist|unless)\\b"
+    - statement: "\\b(:true|:false|:ok|true|false|nil|:nil|is_alive|is_atom|is_binary|is_bitstring|is_boolean|is_exception|is_float|is_function|is_integer|is_list|is_map|is_number|is_pid|is_port|is_range|is_record|is_regex|is_reference|is_tuple|abs|atom_to_binary|atom_to_list|binary_part|binary_to_atom|binary_to_existing_atom|binary_to_float|binary_to_integer|binary_to_list|binary_to_term|bit_size|bitstring_to_list|byte_size|exit|div|elem|float|float_to_binary|float_to_list|\"function_exported?\"|hd|integer_to_binary|integer_to_list|iolist_size|iolist_to_binary|length|list_to_atom|list_to_binary|list_to_bitstring|list_to_existing_atom|list_to_float|list_to_integer|list_to_pid|list_to_tuple|\"macro_exported?\"|make_ref|map_size|\"match?\"|max|min|\"nil?\"|node|pid_to_list|raise|rem|round|self|size|spawn|spawn_link|spawn_monitor|term_to_binary|throw|tl|to_binary|to_char_list|trunc|tuple_size|tuple_to_list|apply|delete_elem|destructure|elem|set_elem|insert_elem|inspect|quote|c|ArgumentError|ArithmeticError|BadArityError|BadFunctionError|BadStructError|CaseClauseError|LoadError|CompileError|CondClauseError|EmptyError|OutOfBoundsError|ErlangError|CopyError|Error|StreamError|KeyError|MatchError|UndefinedError|CompileError|RuntimeError|SyntaxError|SystemLimitError|TokenMissingError|TryClauseError|UndefinedFunctionError|UnicodeConversionError|InvalidRequirementError|InvalidVersionError|Access|Collectable|Enumerable|Inspect|Chars|Iterator|Agent|Any|Application|Atom|Base|Behaviour|Binary|BitString|Bitwise|Code|Dict|EEx|Enum|Exception|ExUnit|File|Function|GenEvent|GenServer|HashDict|HashSet|IEx|Inspect|IO|Kernel|Keyword|List|ListDict|Macro|Map|Mix|Module|Node|Number|OptionParser|Path|PID|Port|Process|Protocol|Range|Record|Reference|Regex|Set|Stream|String|StringIO|Supervisor|System|Task|Tuple|URI|Version|:binary|:elixir_def|:elixir_module|:error|:exit|:kernel|:lists|:math|:throw|:erlang|:gen_server|:supervisor|:gen_event|:docs|:moduledoc)\\b"
+    - constant: "(?i)([ 	]|^)@[0-9A-Z_]+\\b"
+    - constant.number: "\\b[0-9]+\\b"
+    - constant: "(?i)([ 	]|^):[0-9A-Z_]+\\b"
+    - constant: "\\b(__CALLER__|__ENV__|__DIR__|__MODULE__|__aliases__|__block__|alias|case|super|unquote|unquote_splicing|with)\\b"
+    - constant: "~r/([^/]|(\\\\/))*/|~r\\{([^}]|(\\\\}))*\\}"
+    - constant: "~(s|w|c)\\(.*?\\)|~(s|w|c)\\{.*?\\}"
+    - constant: "~w\\(.*?\\)(c|s|a)|~w\\{.*?\\}(c|s|a)"
+    - constant.string: "\\\".*?\\\""
+    - special: "#\\{[^}]*\\}"
+    - constant.string: "\\'.*?\\'"
+    - comment: "#[^{].*$|#$"


### PR DESCRIPTION
I followed the instructions at https://github.com/zyedidia/micro/tree/master/runtime/syntax and used the syntax converter to convert your file to the new yaml format.

It seems to work for me so far, so I though, I'd create a pull request ;-)

Cheers and greetings from Vienna, Austria!